### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/markdownfmt-version-test.el
+++ b/test/markdownfmt-version-test.el
@@ -19,8 +19,6 @@
 ;;; Code:
 
 
-(require 'test-helper)
-
 (ert-deftest test-markdownfmt-library-version ()
   :expected-result (if (executable-find "cask") :passed :failed)
   (let* ((cask-version (car (last (process-lines "cask" "version")))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -80,5 +80,4 @@
          ;; (error
          ;;  (message (ansi-red "[markdownfmt] Error during unit tests : %s" ex))))))
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
*I verified that the tests still succeed after this change.*

The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Also see https://github.com/rejeep/ert-runner.el/issues/38.